### PR TITLE
Added "Flutter For Wordpress" in Open Source Apps

### DIFF
--- a/source.md
+++ b/source.md
@@ -554,6 +554,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Chillify](https://github.com/KarimElghamry/chillify) - Fancy music app made with Provider and Bloc pattern by [Karim Elghamry](https://github.com/KarimElghamry)
 - [Pokedex](https://github.com/scitbiz/flutter_pokedex) - Pokedex app with beautiful UI and smooth animation by [Hung Pham](https://github.com/scitbiz)
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
+- [Flutter For Wordpress](https://github.com/l3lackcurtains/Flutter-for-Wordpress-App) <!--stargazers:l3lackcurtains/Flutter-for-Wordpress-App--> - Starter flutter app for WordPress based news websites by [Madhav Poudel](https://github.com/l3lackcurtains)
 
 ### Games
 


### PR DESCRIPTION
Flutter For Wordpress is starter flutter app for WordPress based news websites.
